### PR TITLE
feat: add godot bullet hell starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
-# bullethell
-bullet hell godot prototype
+# Bullet Hell Starter
+
+Godot 4.3+ 2D bullet-hell starter focusing on performance via object and sound pooling.
+
+## Setup
+
+1. Open `project.godot` with Godot 4.3 or newer.
+2. Autoloads `GameManager` and `AudioManager` are preconfigured in `project.godot`.
+3. Run the project to play the sample mission.
+
+## Project Structure
+
+- `autoload/` – central singletons (`GameManager`, `AudioManager`).
+- `background/` – parallax/tilemap background resources.
+- `components/` – reusable `HealthComponent`, `MovementComponent`, `WeaponComponent`.
+- `effects/` – pooled visual hit effects.
+- `enemies/` – enemy scenes using components.
+- `player/` – player scene and script.
+- `projectiles/` – projectile scene and script.
+- `pools/` – generic `ObjectPool` used for projectiles, enemies, effects.
+- `hud/` – minimal HUD.
+- `missions/` – JSON mission descriptions.
+
+## Extending
+
+- **New enemies**: create a scene with components and add it to a pool. Reference it in mission JSON.
+- **New waves**: edit `missions/mission1.json` or add new mission files and call `GameManager.start_mission()` with the path.
+- **SFX**: place audio files in `sfx/` and reference them in weapon or effect scripts.
+
+## Pools
+
+`ObjectPool` preloads and recycles nodes to avoid runtime instantiation in hot paths. `AudioManager` maintains a pool of `AudioStreamPlayer2D` nodes for low-cost sound playback. Projectiles, enemies and hit effects request instances from their respective pools and release them when finished.
+

--- a/autoload/AudioManager.gd
+++ b/autoload/AudioManager.gd
@@ -1,0 +1,28 @@
+extends Node
+class_name AudioManager
+
+@export var pool_size: int = 16
+
+var available: Array[AudioStreamPlayer2D] = []
+var in_use: Array[AudioStreamPlayer2D] = []
+
+func _ready() -> void:
+	for i in pool_size:
+		var player := AudioStreamPlayer2D.new()
+		player.finished.connect(_on_player_finished.bind(player))
+		add_child(player)
+		available.push_back(player)
+
+func play_sfx(stream: AudioStream, position: Vector2) -> void:
+	if available.is_empty():
+		return
+	var player := available.pop_back()
+	in_use.push_back(player)
+	player.stream = stream
+	player.global_position = position
+	player.play()
+
+func _on_player_finished(player: AudioStreamPlayer2D) -> void:
+	player.stop()
+	in_use.erase(player)
+	available.push_back(player)

--- a/autoload/GameManager.gd
+++ b/autoload/GameManager.gd
@@ -1,0 +1,52 @@
+extends Node
+class_name GameManager
+
+var enemy_pool: ObjectPool
+var projectile_pool: ObjectPool
+var effect_pool: ObjectPool
+
+func initialize(e_pool: ObjectPool, p_pool: ObjectPool, ef_pool: ObjectPool) -> void:
+	enemy_pool = e_pool
+	projectile_pool = p_pool
+	effect_pool = ef_pool
+
+func start_mission(path: String) -> void:
+	var json_text := ""
+	if FileAccess.file_exists(path):
+		json_text = FileAccess.get_file_as_string(path)
+	else:
+		push_error("Mission file not found: %s" % path)
+		return
+	var result := JSON.parse_string(json_text)
+	if typeof(result) != TYPE_DICTIONARY:
+		push_error("Invalid mission data in %s" % path)
+		return
+	await _run_waves(result.get("waves", []))
+
+func _run_waves(waves: Array) -> void:
+	for wave in waves:
+		var count: int = wave.get("count", 0)
+		var interval: float = wave.get("spawn_interval", 1.0)
+		for i in count:
+			if not is_instance_valid(enemy_pool):
+				return
+			var enemy := enemy_pool.get_instance() as Node2D
+			if enemy == null:
+				break
+			var spawn_pos := Vector2(randf_range(0.0, 640.0), -50.0)
+			if enemy.has_method("activate"):
+				enemy.activate(spawn_pos, enemy_pool)
+			await get_tree().create_timer(interval).timeout
+
+func spawn_hit_effect(pos: Vector2) -> void:
+	if not is_instance_valid(effect_pool):
+		return
+	var effect := effect_pool.get_instance() as Node2D
+	if effect == null:
+		return
+	if effect.has_method("activate"):
+		effect.activate(pos, effect_pool)
+
+func on_enemy_killed() -> void:
+	# Placeholder for score handling or wave progress
+	pass

--- a/background/Background.tscn
+++ b/background/Background.tscn
@@ -1,0 +1,19 @@
+[gd_scene load_steps=2 format=4]
+
+[ext_resource path="res://background/tileset.tres" type="TileSet" id=1]
+
+[node name="Background" type="Node2D"]
+
+[node name="ParallaxBackground" type="ParallaxBackground" parent="."]
+
+[node name="Layer1" type="ParallaxLayer" parent="ParallaxBackground"]
+motion_scale = Vector2(0.5, 0.5)
+
+[node name="TileMap1" type="TileMap" parent="ParallaxBackground/Layer1"]
+tile_set = ExtResource("1")
+
+[node name="Layer2" type="ParallaxLayer" parent="ParallaxBackground"]
+motion_scale = Vector2(1, 1)
+
+[node name="TileMap2" type="TileMap" parent="ParallaxBackground/Layer2"]
+tile_set = ExtResource("1")

--- a/background/Tile.tscn
+++ b/background/Tile.tscn
@@ -1,0 +1,7 @@
+[gd_scene load_steps=2 format=4]
+
+[node name="Tile" type="Node2D"]
+
+[node name="Visual" type="Polygon2D" parent="."]
+color = Color(0.2, 0.2, 0.2, 1)
+polygon = PackedVector2Array(0, 0, 32, 0, 32, 32, 0, 32)

--- a/background/tileset.tres
+++ b/background/tileset.tres
@@ -1,0 +1,8 @@
+[gd_resource type="TileSet" load_steps=2 format=3]
+
+[ext_resource path="res://background/Tile.tscn" type="PackedScene" id=1]
+[sub_resource type="TileSetScenesCollectionSource" id=1]
+scenes/0 = {"scene": ExtResource("1")}
+
+[resource]
+sources/0 = SubResource("1")

--- a/components/HealthComponent.gd
+++ b/components/HealthComponent.gd
@@ -1,0 +1,21 @@
+extends Node
+class_name HealthComponent
+
+signal died
+signal health_changed(value: int)
+
+@export var max_health: int = 3
+var current_health: int
+
+func _ready() -> void:
+	current_health = max_health
+
+func take_damage(amount: int) -> void:
+	current_health -= amount
+	health_changed.emit(current_health)
+	if current_health <= 0:
+		died.emit()
+
+func reset() -> void:
+	current_health = max_health
+	health_changed.emit(current_health)

--- a/components/MovementComponent.gd
+++ b/components/MovementComponent.gd
@@ -1,0 +1,11 @@
+extends Node
+class_name MovementComponent
+
+@export var speed: float = 200.0
+@export var direction: Vector2 = Vector2.ZERO
+
+func set_input(dir: Vector2) -> void:
+	direction = dir
+
+func get_velocity() -> Vector2:
+	return direction.normalized() * speed

--- a/components/WeaponComponent.gd
+++ b/components/WeaponComponent.gd
@@ -1,0 +1,32 @@
+extends Node
+class_name WeaponComponent
+
+@export var fire_rate: float = 0.2
+@export var projectile_pool_path: NodePath
+@export var sound_shoot: AudioStream?
+@export var direction: Vector2 = Vector2.UP
+
+var cooldown: float = 0.0
+var projectile_pool: ObjectPool
+
+func _ready() -> void:
+	if projectile_pool_path != NodePath():
+		projectile_pool = get_node(projectile_pool_path)
+
+func _process(delta: float) -> void:
+	if cooldown > 0.0:
+		cooldown -= delta
+
+func shoot(origin: Vector2) -> void:
+	if cooldown > 0.0:
+		return
+	if projectile_pool == null:
+		return
+	var projectile := projectile_pool.get_instance() as Node2D
+	if projectile == null:
+		return
+	if projectile.has_method("activate"):
+		projectile.activate(origin, direction, projectile_pool)
+	cooldown = fire_rate
+	if sound_shoot:
+		AudioManager.play_sfx(sound_shoot, origin)

--- a/effects/HitEffect.gd
+++ b/effects/HitEffect.gd
@@ -1,0 +1,18 @@
+extends Node2D
+class_name HitEffect
+
+@export var duration: float = 0.2
+var pool: ObjectPool
+
+@onready var timer: Timer = $Timer
+
+func activate(pos: Vector2, pool_ref: ObjectPool) -> void:
+	position = pos
+	pool = pool_ref
+	visible = true
+	timer.start(duration)
+
+func _on_timer_timeout() -> void:
+	visible = false
+	if is_instance_valid(pool):
+		pool.release_instance(self)

--- a/effects/HitEffect.tscn
+++ b/effects/HitEffect.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=2 format=4]
+
+[ext_resource path="res://effects/HitEffect.gd" type="Script" id=1]
+
+[node name="HitEffect" type="Node2D"]
+script = ExtResource("1")
+
+[node name="Visual" type="Polygon2D" parent="."]
+color = Color(1, 1, 0, 1)
+polygon = PackedVector2Array(-4, -4, 4, -4, 4, 4, -4, 4)
+
+[node name="Timer" type="Timer" parent="."]
+one_shot = true
+autostart = false
+
+[connection signal="timeout" from="Timer" to="." method="_on_timer_timeout"]

--- a/enemies/Enemy.gd
+++ b/enemies/Enemy.gd
@@ -1,0 +1,32 @@
+extends Node2D
+class_name Enemy
+
+@onready var health: HealthComponent = $HealthComponent
+@onready var movement: MovementComponent = $MovementComponent
+var pool: ObjectPool
+
+func _ready() -> void:
+	health.died.connect(_on_died)
+
+func activate(pos: Vector2, pool_ref: ObjectPool) -> void:
+	position = pos
+	pool = pool_ref
+	visible = true
+	health.reset()
+	set_process(true)
+
+func _process(delta: float) -> void:
+	position += movement.get_velocity() * delta
+	if position.y > get_viewport_rect().size.y + 50.0:
+		_deactivate()
+
+func _on_died() -> void:
+	GameManager.on_enemy_killed()
+	GameManager.spawn_hit_effect(global_position)
+	_deactivate()
+
+func _deactivate() -> void:
+	set_process(false)
+	visible = false
+	if is_instance_valid(pool):
+		pool.release_instance(self)

--- a/enemies/Enemy.tscn
+++ b/enemies/Enemy.tscn
@@ -1,0 +1,31 @@
+[gd_scene load_steps=4 format=4]
+
+[ext_resource path="res://enemies/Enemy.gd" type="Script" id=1]
+[ext_resource path="res://components/HealthComponent.gd" type="Script" id=2]
+[ext_resource path="res://components/MovementComponent.gd" type="Script" id=3]
+
+[sub_resource type="CircleShape2D" id=1]
+radius = 8.0
+
+[node name="Enemy" type="Node2D"]
+script = ExtResource("1")
+
+[node name="Visual" type="Polygon2D" parent="."]
+color = Color(1, 0, 0, 1)
+polygon = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+
+[node name="CollisionArea" type="Area2D" parent="."]
+collision_layer = 1
+collision_mask = 1
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="CollisionArea"]
+shape = SubResource("1")
+
+[node name="HealthComponent" type="Node" parent="."]
+script = ExtResource("2")
+max_health = 3
+
+[node name="MovementComponent" type="Node" parent="."]
+script = ExtResource("3")
+speed = 100.0
+direction = Vector2.DOWN

--- a/hud/HUD.gd
+++ b/hud/HUD.gd
@@ -1,0 +1,7 @@
+extends CanvasLayer
+class_name HUD
+
+@onready var health_label: Label = $HealthLabel
+
+func update_health(value: int) -> void:
+	health_label.text = "Health: %d" % value

--- a/hud/HUD.tscn
+++ b/hud/HUD.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=4]
+
+[ext_resource path="res://hud/HUD.gd" type="Script" id=1]
+
+[node name="HUD" type="CanvasLayer"]
+script = ExtResource("1")
+
+[node name="HealthLabel" type="Label" parent="."]
+text = "Health: 0"

--- a/missions/mission1.json
+++ b/missions/mission1.json
@@ -1,0 +1,9 @@
+{
+  "waves": [
+    {
+      "enemy_scene": "res://enemies/Enemy.tscn",
+      "count": 5,
+      "spawn_interval": 0.5
+    }
+  ]
+}

--- a/player/Player.gd
+++ b/player/Player.gd
@@ -1,0 +1,20 @@
+extends CharacterBody2D
+class_name Player
+
+@onready var movement: MovementComponent = $MovementComponent
+@onready var weapon: WeaponComponent = $WeaponComponent
+@onready var health: HealthComponent = $HealthComponent
+
+func _ready() -> void:
+	health.died.connect(_on_died)
+
+func _physics_process(delta: float) -> void:
+	var dir := Input.get_vector("ui_left", "ui_right", "ui_up", "ui_down")
+	movement.set_input(dir)
+	velocity = movement.get_velocity()
+	move_and_slide()
+	if Input.is_action_pressed("shoot"):
+		weapon.shoot(global_position)
+
+func _on_died() -> void:
+	hide()

--- a/player/Player.tscn
+++ b/player/Player.tscn
@@ -1,0 +1,31 @@
+[gd_scene load_steps=5 format=4]
+
+[ext_resource path="res://player/Player.gd" type="Script" id=1]
+[ext_resource path="res://components/HealthComponent.gd" type="Script" id=2]
+[ext_resource path="res://components/WeaponComponent.gd" type="Script" id=3]
+[ext_resource path="res://components/MovementComponent.gd" type="Script" id=4]
+
+[sub_resource type="CircleShape2D" id=1]
+radius = 8.0
+
+[node name="Player" type="CharacterBody2D"]
+script = ExtResource("1")
+
+[node name="Visual" type="Polygon2D" parent="."]
+color = Color(0, 0.5, 1, 1)
+polygon = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("1")
+
+[node name="HealthComponent" type="Node" parent="."]
+script = ExtResource("2")
+max_health = 5
+
+[node name="WeaponComponent" type="Node" parent="."]
+script = ExtResource("3")
+fire_rate = 0.15
+
+[node name="MovementComponent" type="Node" parent="."]
+script = ExtResource("4")
+speed = 250.0

--- a/pools/ObjectPool.gd
+++ b/pools/ObjectPool.gd
@@ -1,0 +1,30 @@
+extends Node
+class_name ObjectPool
+
+@export var scene: PackedScene
+@export var size: int = 16
+
+var available: Array[Node] = []
+var in_use: Array[Node] = []
+
+func _ready() -> void:
+	for i in size:
+		var inst := scene.instantiate()
+		inst.visible = false
+		add_child(inst)
+		available.push_back(inst)
+
+func get_instance() -> Node:
+	if available.is_empty():
+		return null
+	var inst := available.pop_back()
+	in_use.push_back(inst)
+	inst.visible = true
+	return inst
+
+func release_instance(node: Node) -> void:
+	if not in_use.has(node):
+		return
+	in_use.erase(node)
+	node.visible = false
+	available.push_back(node)

--- a/project.godot
+++ b/project.godot
@@ -1,0 +1,19 @@
+; Engine configuration file.
+; It's best edited using the editor.
+; Manual changes may break things.
+
+[application]
+config/name="BulletHell"
+run/main_scene="res://scenes/Main.tscn"
+config/features=PackedStringArray("4.3")
+
+[autoload]
+GameManager="res://autoload/GameManager.gd"
+AudioManager="res://autoload/AudioManager.gd"
+
+[input]
+ui_left={"deadzone":0.5,"events":[{"type":"InputEventKey","keycode":16777231}]}
+ui_right={"deadzone":0.5,"events":[{"type":"InputEventKey","keycode":16777233}]}
+ui_up={"deadzone":0.5,"events":[{"type":"InputEventKey","keycode":16777232}]}
+ui_down={"deadzone":0.5,"events":[{"type":"InputEventKey","keycode":16777234}]}
+shoot={"deadzone":0.5,"events":[{"type":"InputEventKey","keycode":32}]}

--- a/projectiles/Projectile.gd
+++ b/projectiles/Projectile.gd
@@ -1,0 +1,35 @@
+extends Area2D
+class_name Projectile
+
+@export var speed: float = 400.0
+
+var velocity: Vector2 = Vector2.ZERO
+var pool: ObjectPool
+
+@onready var notifier: VisibleOnScreenNotifier2D = $VisibleOnScreenNotifier2D
+@onready var collision: CollisionShape2D = $CollisionShape2D
+
+func activate(pos: Vector2, dir: Vector2, pool_ref: ObjectPool) -> void:
+	position = pos
+	velocity = dir.normalized() * speed
+	pool = pool_ref
+	visible = true
+	collision.disabled = false
+
+func _physics_process(delta: float) -> void:
+	position += velocity * delta
+
+func _on_area_entered(area: Area2D) -> void:
+	if area.has_method("take_damage"):
+		area.take_damage(1)
+	GameManager.spawn_hit_effect(global_position)
+	_deactivate()
+
+func _on_visible_on_screen_notifier_2d_screen_exited() -> void:
+	_deactivate()
+
+func _deactivate() -> void:
+	collision.disabled = true
+	visible = false
+	if is_instance_valid(pool):
+		pool.release_instance(self)

--- a/projectiles/Projectile.tscn
+++ b/projectiles/Projectile.tscn
@@ -1,0 +1,23 @@
+[gd_scene load_steps=2 format=4]
+
+[ext_resource path="res://projectiles/Projectile.gd" type="Script" id=1]
+
+[sub_resource type="CircleShape2D" id=1]
+radius = 4.0
+
+[node name="Projectile" type="Area2D"]
+script = ExtResource("1")
+collision_layer = 2
+collision_mask = 1
+
+[node name="Visual" type="Polygon2D" parent="."]
+color = Color(1, 1, 1, 1)
+polygon = PackedVector2Array(-2, -2, 2, -2, 2, 2, -2, 2)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("1")
+
+[node name="VisibleOnScreenNotifier2D" type="VisibleOnScreenNotifier2D" parent="."]
+
+[connection signal="area_entered" from="Projectile" to="." method="_on_area_entered"]
+[connection signal="screen_exited" from="VisibleOnScreenNotifier2D" to="." method="_on_visible_on_screen_notifier_2d_screen_exited"]

--- a/scenes/Main.gd
+++ b/scenes/Main.gd
@@ -1,0 +1,19 @@
+extends Node2D
+class_name Main
+
+@onready var player: Player = $Player
+@onready var hud: HUD = $HUD
+@onready var projectile_pool: ObjectPool = $ProjectilePool
+@onready var enemy_pool: ObjectPool = $EnemyPool
+@onready var effect_pool: ObjectPool = $EffectPool
+
+func _ready() -> void:
+	GameManager.initialize(enemy_pool, projectile_pool, effect_pool)
+	var health_comp: HealthComponent = player.get_node("HealthComponent")
+	health_comp.health_changed.connect(hud.update_health)
+	health_comp.died.connect(_on_player_died)
+	hud.update_health(health_comp.current_health)
+	GameManager.start_mission("res://missions/mission1.json")
+
+func _on_player_died() -> void:
+	get_tree().reload_current_scene()

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -1,0 +1,37 @@
+[gd_scene load_steps=8 format=4]
+
+[ext_resource path="res://scenes/Main.gd" type="Script" id=1]
+[ext_resource path="res://background/Background.tscn" type="PackedScene" id=2]
+[ext_resource path="res://player/Player.tscn" type="PackedScene" id=3]
+[ext_resource path="res://hud/HUD.tscn" type="PackedScene" id=4]
+[ext_resource path="res://projectiles/Projectile.tscn" type="PackedScene" id=5]
+[ext_resource path="res://pools/ObjectPool.gd" type="Script" id=6]
+[ext_resource path="res://effects/HitEffect.tscn" type="PackedScene" id=7]
+[ext_resource path="res://enemies/Enemy.tscn" type="PackedScene" id=8]
+
+[node name="Main" type="Node2D"]
+script = ExtResource("1")
+
+[node name="Background" parent="." instance=ExtResource("2")]
+
+[node name="ProjectilePool" type="Node" parent="." groups=["projectile_pool"]]
+script = ExtResource("6")
+scene = ExtResource("5")
+size = 128
+
+[node name="EnemyPool" type="Node" parent="." groups=["enemy_pool"]]
+script = ExtResource("6")
+scene = ExtResource("8")
+size = 32
+
+[node name="EffectPool" type="Node" parent="." groups=["effect_pool"]]
+script = ExtResource("6")
+scene = ExtResource("7")
+size = 32
+
+[node name="Player" parent="." instance=ExtResource("3")]
+
+[node name="WeaponComponent" parent="Player"]
+projectile_pool_path = NodePath("../ProjectilePool")
+
+[node name="HUD" parent="." instance=ExtResource("4")]


### PR DESCRIPTION
## Summary
- add object, enemy, effect, and audio pooling systems
- implement modular player, enemy, and projectile components
- provide parallax tilemap background and mission JSON loader
- remove binary placeholder texture and use vector-based visuals

## Testing
- `godot --version` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68c2ebf710ec832e9982b19c311515a8