### PR TITLE
Add Xbox controller input and sample level

### DIFF
--- a/enemy/Miniboss.gd
+++ b/enemy/Miniboss.gd
@@ -1,0 +1,8 @@
+extends Enemy
+class_name Miniboss
+
+@export var start_pattern: StringName = &"PatternSpiral"
+
+func _ready() -> void:
+	# Activate miniboss with given pattern
+	activate(position, start_pattern)

--- a/enemy/Miniboss.tscn
+++ b/enemy/Miniboss.tscn
@@ -1,0 +1,36 @@
+[gd_scene format=3 uid="10"]
+
+[ext_resource path="res://enemy/Miniboss.gd" type="Script" id=1]
+[ext_resource path="res://enemy/patterns/PatternSpiral.gd" type="Script" id=2]
+[ext_resource path="res://enemy/patterns/PatternFan.gd" type="Script" id=3]
+[ext_resource path="res://enemy/patterns/PatternRain.gd" type="Script" id=4]
+
+[sub_resource type="CircleShape2D" id=1]
+radius = 16.0
+
+[node name="Miniboss" type="Area2D"]
+collision_layer = 4
+collision_mask = 1
+script = ExtResource("1")
+max_hp = 20
+point_value = 500
+contact_damage = 2
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+scale = Vector2(2, 2)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource(1)
+
+[node name="Patterns" type="Node" parent="."]
+
+[node name="PatternSpiral" type="Node" parent="Patterns"]
+script = ExtResource("2")
+
+[node name="PatternFan" type="Node" parent="Patterns"]
+script = ExtResource("3")
+
+[node name="PatternRain" type="Node" parent="Patterns"]
+script = ExtResource("4")
+
+[connection signal="body_entered" from="." to="." method="_on_body_entered"]

--- a/enemy/SampleEnemy.gd
+++ b/enemy/SampleEnemy.gd
@@ -1,0 +1,8 @@
+extends Enemy
+class_name SampleEnemy
+
+@export var start_pattern: StringName = &"PatternFan"
+
+func _ready() -> void:
+	# Activate with default pattern
+	activate(position, start_pattern)

--- a/enemy/SampleEnemy.tscn
+++ b/enemy/SampleEnemy.tscn
@@ -1,0 +1,32 @@
+[gd_scene format=3 uid="9"]
+
+[ext_resource path="res://enemy/SampleEnemy.gd" type="Script" id=1]
+[ext_resource path="res://enemy/patterns/PatternSpiral.gd" type="Script" id=2]
+[ext_resource path="res://enemy/patterns/PatternFan.gd" type="Script" id=3]
+[ext_resource path="res://enemy/patterns/PatternRain.gd" type="Script" id=4]
+
+[sub_resource type="CircleShape2D" id=1]
+radius = 8.0
+
+[node name="SampleEnemy" type="Area2D"]
+collision_layer = 4
+collision_mask = 1
+script = ExtResource("1")
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource(1)
+
+[node name="Patterns" type="Node" parent="."]
+
+[node name="PatternSpiral" type="Node" parent="Patterns"]
+script = ExtResource("2")
+
+[node name="PatternFan" type="Node" parent="Patterns"]
+script = ExtResource("3")
+
+[node name="PatternRain" type="Node" parent="Patterns"]
+script = ExtResource("4")
+
+[connection signal="body_entered" from="." to="." method="_on_body_entered"]

--- a/levels/SampleMap.tscn
+++ b/levels/SampleMap.tscn
@@ -1,0 +1,26 @@
+[gd_scene format=3 uid="11"]
+
+[ext_resource path="res://levels/LevelController.gd" type="Script" id=1]
+[ext_resource path="res://assets/tiles/space_tileset.tres" type="TileSet" id=2]
+[ext_resource path="res://player/Player.tscn" type="PackedScene" id=3]
+[ext_resource path="res://enemy/Spawner.tscn" type="PackedScene" id=4]
+[ext_resource path="res://enemy/Miniboss.tscn" type="PackedScene" id=5]
+[ext_resource path="res://ui/HUD.tscn" type="PackedScene" id=6]
+
+[node name="SampleMap" type="Node2D"]
+script = ExtResource("1")
+
+[node name="BG" type="TileMap" parent="."]
+tile_set = ExtResource("2")
+cell_size = Vector2i(32, 32)
+
+[node name="Player" parent="." instance=ExtResource("3")]
+position = Vector2(0, 200)
+
+[node name="Spawner" parent="." instance=ExtResource("4")]
+waves = [{"time":1.0,"pattern":&"PatternFan","pos":Vector2(-60,-120)},{"time":2.5,"pattern":&"PatternSpiral","pos":Vector2(60,-150)},{"time":4.0,"pattern":&"PatternRain","pos":Vector2(0,-170)}]
+
+[node name="Miniboss" parent="." instance=ExtResource("5")]
+position = Vector2(0, -240)
+
+[node name="HUD" parent="." instance=ExtResource("6")]

--- a/main.tscn
+++ b/main.tscn
@@ -1,7 +1,7 @@
 [gd_scene format=3 uid="8"]
 
-[ext_resource path="res://levels/Level01.tscn" type="PackedScene" id=1]
+[ext_resource path="res://levels/SampleMap.tscn" type="PackedScene" id=1]
 
 [node name="Main" type="Node"]
 
-[node name="Level01" parent="." instance=ExtResource("1")]
+[node name="SampleMap" parent="." instance=ExtResource("1")]

--- a/player/Player.gd
+++ b/player/Player.gd
@@ -10,10 +10,13 @@ class_name Player
 var shoot_cd: float = 0.0
 var invincible: float = 0.0
 var team: int = 0
+var current_weapon: int = 0
+var weapons: Array[StringName] = [&"default"]
 
 func _physics_process(delta: float) -> void:
 	_handle_movement(delta)
 	_handle_shooting(delta)
+	_handle_specials()
 	if invincible > 0.0:
 		invincible -= delta
 
@@ -42,6 +45,15 @@ func _handle_shooting(delta: float) -> void:
 		get_tree().current_scene.add_child(b)
 		b.fire(global_position, Vector2.UP, bullet_speed, team)
 		GameSignals.play_sfx.emit(&"shoot")
+
+
+func _handle_specials() -> void:
+	# Special weapon activation
+	if Input.is_action_just_pressed(&"special_weapon"):
+		GameSignals.play_sfx.emit(&"special")
+	# Cycle through available weapons
+	if Input.is_action_just_pressed(&"switch_weapon"):
+		current_weapon = (current_weapon + 1) % weapons.size()
 
 func take_damage(amount: int) -> void:
 	if invincible > 0.0:

--- a/project.godot
+++ b/project.godot
@@ -9,10 +9,12 @@ PoolManager="*res://core/PoolManager.gd"
 SoundPool="*res://core/SoundPool.gd"
 
 [input]
-move_up={"deadzone":0.5,"events":[{"type":"key","keycode":87},{"type":"key","keycode":16777232}]}
-move_down={"deadzone":0.5,"events":[{"type":"key","keycode":83},{"type":"key","keycode":16777234}]}
-move_left={"deadzone":0.5,"events":[{"type":"key","keycode":65},{"type":"key","keycode":16777231}]}
-move_right={"deadzone":0.5,"events":[{"type":"key","keycode":68},{"type":"key","keycode":16777233}]}
-shoot={"deadzone":0.5,"events":[{"type":"key","keycode":32},{"type":"mouse_button","button_index":1}]}
-focus={"deadzone":0.5,"events":[{"type":"key","keycode":16777237}]}
-pause={"deadzone":0.5,"events":[{"type":"key","keycode":16777217},{"type":"key","keycode":80}]}
+move_up={"deadzone":0.5,"events":[{"type":"key","keycode":87},{"type":"key","keycode":16777232},{"type":"joypad_motion","axis":1,"axis_value":-1.0},{"type":"joypad_button","button_index":12}]}
+move_down={"deadzone":0.5,"events":[{"type":"key","keycode":83},{"type":"key","keycode":16777234},{"type":"joypad_motion","axis":1,"axis_value":1.0},{"type":"joypad_button","button_index":13}]}
+move_left={"deadzone":0.5,"events":[{"type":"key","keycode":65},{"type":"key","keycode":16777231},{"type":"joypad_motion","axis":0,"axis_value":-1.0},{"type":"joypad_button","button_index":14}]}
+move_right={"deadzone":0.5,"events":[{"type":"key","keycode":68},{"type":"key","keycode":16777233},{"type":"joypad_motion","axis":0,"axis_value":1.0},{"type":"joypad_button","button_index":15}]}
+shoot={"deadzone":0.5,"events":[{"type":"key","keycode":32},{"type":"mouse_button","button_index":1},{"type":"joypad_button","button_index":0}]}
+focus={"deadzone":0.5,"events":[{"type":"key","keycode":16777237},{"type":"joypad_button","button_index":4}]}
+pause={"deadzone":0.5,"events":[{"type":"key","keycode":16777217},{"type":"key","keycode":80},{"type":"joypad_button","button_index":7}]}
+special_weapon={"deadzone":0.5,"events":[{"type":"key","keycode":69},{"type":"joypad_button","button_index":1}]}
+switch_weapon={"deadzone":0.5,"events":[{"type":"key","keycode":81},{"type":"joypad_button","button_index":3}]}


### PR DESCRIPTION
## Summary
- add Xbox controller mappings for movement, firing, and weapon actions
- introduce SampleEnemy and Miniboss scenes with activation scripts
- create SampleMap demonstrating varied enemy waves and a miniboss

## Testing
- `godot4 --headless --check project.godot` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3f6101d04832e8b602987e8a4baa2