### PR TITLE
Add circle and flower bullet patterns

### DIFF
--- a/enemy/SampleEnemy.tscn
+++ b/enemy/SampleEnemy.tscn
@@ -4,6 +4,8 @@
 [ext_resource path="res://enemy/patterns/PatternSpiral.gd" type="Script" id=2]
 [ext_resource path="res://enemy/patterns/PatternFan.gd" type="Script" id=3]
 [ext_resource path="res://enemy/patterns/PatternRain.gd" type="Script" id=4]
+[ext_resource path="res://enemy/patterns/PatternCircle.gd" type="Script" id=5]
+[ext_resource path="res://enemy/patterns/PatternFlower.gd" type="Script" id=6]
 
 [sub_resource type="CircleShape2D" id=1]
 radius = 8.0
@@ -28,5 +30,11 @@ script = ExtResource("3")
 
 [node name="PatternRain" type="Node" parent="Patterns"]
 script = ExtResource("4")
+
+[node name="PatternCircle" type="Node" parent="Patterns"]
+script = ExtResource("5")
+
+[node name="PatternFlower" type="Node" parent="Patterns"]
+script = ExtResource("6")
 
 [connection signal="body_entered" from="." to="." method="_on_body_entered"]

--- a/enemy/patterns/PatternCircle.gd
+++ b/enemy/patterns/PatternCircle.gd
@@ -1,0 +1,25 @@
+extends PatternBase
+class_name PatternCircle
+
+@export var bullet_speed: float = 200.0
+@export var count: int = 12
+@export var interval: float = 1.0
+var timer: float = 0.0
+
+func setup(enemy: Node, params: Dictionary) -> void:
+	# Reset timer whenever this pattern is activated
+	timer = 0.0
+
+func tick(enemy: Node, delta: float) -> void:
+	# Emit a ring of bullets around the enemy at fixed intervals
+	if not active:
+		return
+	timer -= delta
+	if timer <= 0.0:
+		timer = interval
+		for i in count:
+			var angle := TAU * (i / float(max(1, count)))
+			var dir := Vector2.RIGHT.rotated(angle)
+			var b := PoolManager.get_from_pool(&"enemy_bullets") as Bullet
+			enemy.get_parent().add_child(b)
+			b.fire(enemy.global_position, dir, bullet_speed, 1)

--- a/enemy/patterns/PatternFlower.gd
+++ b/enemy/patterns/PatternFlower.gd
@@ -1,0 +1,29 @@
+extends PatternBase
+class_name PatternFlower
+
+@export var bullet_speed: float = 180.0
+@export var count: int = 16
+@export var interval: float = 0.6
+@export var rotate_speed: float = 0.2
+var timer: float = 0.0
+var angle_offset: float = 0.0
+
+func setup(enemy: Node, params: Dictionary) -> void:
+	# Prepare timer and initial rotation offset
+	timer = 0.0
+	angle_offset = params.get("start_angle", 0.0)
+
+func tick(enemy: Node, delta: float) -> void:
+	# Fire rotating rings for a flower-like spread
+	if not active:
+		return
+	timer -= delta
+	angle_offset += rotate_speed * delta
+	if timer <= 0.0:
+		timer = interval
+		for i in count:
+			var angle := angle_offset + TAU * (i / float(max(1, count)))
+			var dir := Vector2.RIGHT.rotated(angle)
+			var b := PoolManager.get_from_pool(&"enemy_bullets") as Bullet
+			enemy.get_parent().add_child(b)
+			b.fire(enemy.global_position, dir, bullet_speed, 1)


### PR DESCRIPTION
## Summary
- Add PatternCircle for circular bullet rings inspired by CAVE shooters
- Add PatternFlower for rotating radial bursts
- Register new patterns in SampleEnemy scene

## Testing
- `godot3 --version`
- `godot3 --no-window --quit` *(fails: X11 Display is not available)*

------
https://chatgpt.com/codex/tasks/task_e_68c3f806bb64832e82c77ddacc0782c9