### PR TITLE
Add title screen and extra life rewards

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="BulletHell"
-run/main_scene="res://main.tscn"
+run/main_scene="res://ui/TitleScreen.tscn"
 config/features=PackedStringArray("4.4")
 
 [autoload]

--- a/ui/HUD.gd
+++ b/ui/HUD.gd
@@ -6,6 +6,10 @@ var score: int = 0
 @export var flash_duration: float = 0.3
 @export var flash_max_alpha: float = 0.4
 var flash_time: float = 0.0
+@export var extra_life_score: int = 100000
+var next_life_score: int = extra_life_score
+
+@onready var player: Player = get_parent().get_node("Player")
 
 @onready var score_label: Label = $Score
 @onready var lives_label: Label = $Lives
@@ -30,13 +34,23 @@ func _on_player_hit(damage: int) -> void:
 
 func _on_enemy_killed(points: int) -> void:
 	score += points
+	_check_extra_life()
 	_update()
 
 func _on_star_collected(points: int, at: Vector2) -> void:
 	score += points
+	_check_extra_life()
 	flash_time = flash_duration
 	flash_rect.modulate.a = flash_max_alpha
 	_update()
+
+func _check_extra_life() -> void:
+	# Grant extra lives for reaching score thresholds
+	while score >= next_life_score:
+		lives += 1
+		if is_instance_valid(player):
+			player.lives += 1
+		next_life_score += extra_life_score
 
 func _update() -> void:
 	score_label.text = str(score)

--- a/ui/TitleScreen.gd
+++ b/ui/TitleScreen.gd
@@ -1,0 +1,11 @@
+extends Control
+class_name TitleScreen
+
+@onready var start_button: Button = $StartButton
+
+func _ready() -> void:
+	# Connect start button to launch new game
+	start_button.pressed.connect(_on_start_pressed)
+
+func _on_start_pressed() -> void:
+	get_tree().change_scene_to_file("res://main.tscn")

--- a/ui/TitleScreen.tscn
+++ b/ui/TitleScreen.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://ui/TitleScreen.gd" id="1"]
+
+[node name="TitleScreen" type="Control"]
+script = ExtResource("1")
+
+[node name="StartButton" type="Button" parent="."]
+position = Vector2(200, 200)
+text = "Start"


### PR DESCRIPTION
## Summary
- Add TitleScreen scene with Start button to begin a new game
- Grant extra lives every 100000 points in HUD and sync with player
- Set TitleScreen as the project's main scene

## Testing
- `godot --headless --quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4212759a0832e9be4487aa4333ca2