### PR TITLE
feat: enhance hud and sample level

### DIFF
--- a/fx/ScorePopup.tscn
+++ b/fx/ScorePopup.tscn
@@ -11,4 +11,4 @@ offset_top = -10.0
 offset_right = 20.0
 offset_bottom = 10.0
 text = "+100"
-theme_override_font_sizes/font_size = 32
+theme_override_font_sizes/font_size = 80

--- a/levels/LevelController.gd
+++ b/levels/LevelController.gd
@@ -2,12 +2,14 @@ extends Node2D
 class_name LevelController
 
 @export var scroll_speed: float = 40.0
+@export var level_name: String = ""
 @onready var spawner: Spawner = $Spawner
 @onready var hud: HUD = $HUD
 @onready var bg: TileMap = $BG
 
 func _ready() -> void:
 	GameSignals.spawn_request.connect(_on_spawn_request)
+	hud.set_level_name(level_name if level_name != "" else name)
 
 func _process(delta: float) -> void:
 	bg.position.y += scroll_speed * delta

--- a/levels/SampleMap.tscn
+++ b/levels/SampleMap.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://c6nfncd8dlva"]
+[gd_scene load_steps=8 format=3 uid="uid://c6nfncd8dlva"]
 
 [ext_resource type="Script" uid="uid://0u0ggwicthpx" path="res://levels/LevelController.gd" id="1"]
 [ext_resource type="TileSet" path="res://assets/tiles/space_tileset.tres" id="2"]
@@ -6,9 +6,11 @@
 [ext_resource type="PackedScene" uid="uid://boo060d7wi7tp" path="res://enemy/Spawner.tscn" id="4"]
 [ext_resource type="PackedScene" uid="uid://cjk7m7xy4mptc" path="res://enemy/Miniboss.tscn" id="5"]
 [ext_resource type="PackedScene" uid="uid://do0mdp7086duo" path="res://ui/HUD.tscn" id="6"]
+[ext_resource type="PackedScene" uid="uid://cb5dy8x3r2ofi" path="res://enemy/SampleEnemy.tscn" id="7"]
 
 [node name="SampleMap" type="Node2D"]
 script = ExtResource("1")
+level_name = "Sample Level"
 
 [node name="BG" type="TileMap" parent="."]
 tile_set = ExtResource("2")
@@ -57,8 +59,60 @@ waves = [{
 }, {
 "pattern": &"PatternChase",
 "pos": Vector2(40, -180),
-"time": 10.0
+"time": 10.0,
+}, {
+"pattern": &"PatternStraight",
+"pos": Vector2(80, -120),
+"time": 11.0,
+}, {
+"pattern": &"PatternZigzag",
+"pos": Vector2(-80, -120),
+"time": 12.0,
+}, {
+"pattern": &"PatternSine",
+"pos": Vector2(0, -150),
+"time": 13.0,
+}, {
+"pattern": &"PatternCircle",
+"pos": Vector2(60, -150),
+"time": 14.0,
+}, {
+"pattern": &"PatternFan",
+"pos": Vector2(-60, -150),
+"time": 15.0,
+}, {
+"pattern": &"PatternFlower",
+"pos": Vector2(0, -170),
+"time": 16.0,
+}, {
+"pattern": &"PatternRain",
+"pos": Vector2(80, -170),
+"time": 17.0,
+}, {
+"pattern": &"PatternSpiral",
+"pos": Vector2(-80, -170),
+"time": 18.0,
+}, {
+"pattern": &"PatternBurst",
+"pos": Vector2(40, -180),
+"time": 19.0,
+}, {
+"pattern": &"PatternChase",
+"pos": Vector2(-40, -180),
+"time": 20.0,
 }]
+
+[node name="SampleEnemy1" parent="." instance=ExtResource("7")]
+position = Vector2(-120, -200)
+start_pattern = &"PatternFan"
+
+[node name="SampleEnemy2" parent="." instance=ExtResource("7")]
+position = Vector2(0, -220)
+start_pattern = &"PatternCircle"
+
+[node name="SampleEnemy3" parent="." instance=ExtResource("7")]
+position = Vector2(120, -200)
+start_pattern = &"PatternSpiral"
 
 [node name="Miniboss" parent="." instance=ExtResource("5")]
 position = Vector2(0, -240)

--- a/ui/HUD.gd
+++ b/ui/HUD.gd
@@ -14,12 +14,16 @@ var next_life_score: int = extra_life_score
 @onready var score_label: Label = $Score
 @onready var lives_label: Label = $Lives
 @onready var flash_rect: ColorRect = $Flash
+@onready var level_name_label: Label = $LevelName
 
 func _ready() -> void:
 	_update()
 	GameSignals.player_hit.connect(_on_player_hit)
 	GameSignals.enemy_killed.connect(_on_enemy_killed)
 	GameSignals.star_collected.connect(_on_star_collected)
+
+func set_level_name(name: String) -> void:
+	level_name_label.text = name
 
 func _process(delta: float) -> void:
 	if flash_time > 0.0:

--- a/ui/HUD.tscn
+++ b/ui/HUD.tscn
@@ -5,19 +5,29 @@
 [node name="HUD" type="CanvasLayer"]
 script = ExtResource("1")
 
-[node name="Score" type="Label" parent="."]
+[node name="LevelName" type="Label" parent="."]
 offset_left = 10.0
 offset_top = 10.0
 offset_right = 10.0
 offset_bottom = 10.0
+text = ""
+theme_override_font_sizes/font_size = 40
+
+[node name="Score" type="Label" parent="."]
+offset_left = 10.0
+offset_top = 60.0
+offset_right = 10.0
+offset_bottom = 60.0
 text = "0"
+theme_override_font_sizes/font_size = 40
 
 [node name="Lives" type="Label" parent="."]
 offset_left = 10.0
-offset_top = 30.0
+offset_top = 110.0
 offset_right = 10.0
-offset_bottom = 30.0
+offset_bottom = 110.0
 text = "3"
+theme_override_font_sizes/font_size = 40
 
 [node name="Flash" type="ColorRect" parent="."]
 anchors_preset = 15

--- a/ui/TitleScreen.tscn
+++ b/ui/TitleScreen.tscn
@@ -8,3 +8,4 @@ script = ExtResource("1")
 [node name="StartButton" type="Button" parent="."]
 position = Vector2(200, 200)
 text = "Start"
+theme_override_font_sizes/font_size = 40


### PR DESCRIPTION
## Summary
- display level name on HUD and enlarge all on-screen text
- show all enemy types and increase enemy waves in sample level

## Testing
- `godot --headless -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c457e2b058832ea1e04326e87c87cc