### PR TITLE
Add basic level editor scene and menu access

### DIFF
--- a/levels/LevelEditor.gd
+++ b/levels/LevelEditor.gd
@@ -1,0 +1,35 @@
+extends Node2D
+class_name LevelEditor
+
+@export var tilemap_path: NodePath
+@export var level_save_path: String = "res://levels/custom_level.tscn"
+@onready var tilemap: TileMap = get_node(tilemap_path)
+
+var current_tile: int = 0
+
+func _ready() -> void:
+	# Ensure tilemap exists before editing
+	if !is_instance_valid(tilemap):
+		push_error("TileMap not found: %s" % tilemap_path)
+
+func _unhandled_input(event: InputEvent) -> void:
+	# Paint or erase tiles based on mouse input
+	if event is InputEventMouseButton and event.pressed:
+		var local_pos := tilemap.to_local(get_global_mouse_position())
+		var cell := tilemap.local_to_map(local_pos)
+		if event.button_index == MouseButton.LEFT:
+			# Place selected tile
+			tilemap.set_cell(0, cell, current_tile)
+		elif event.button_index == MouseButton.RIGHT:
+			# Erase tile
+			tilemap.set_cell(0, cell, -1)
+
+func save_level() -> void:
+	# Save current level to disk
+	var packed := PackedScene.new()
+	if packed.pack(self) == OK:
+		var res := ResourceSaver.save(level_save_path, packed)
+		if res != OK:
+			push_error("Failed to save level: %s" % level_save_path)
+	else:
+		push_error("Failed to pack scene for saving")

--- a/levels/LevelEditor.tscn
+++ b/levels/LevelEditor.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://levels/LevelEditor.gd" id="1"]
+[ext_resource type="TileSet" path="res://assets/tiles/space_tileset.tres" id="2"]
+
+[node name="LevelEditor" type="Node2D"]
+script = ExtResource("1")
+
+[node name="BG" type="TileMap" parent="."]
+tile_set = ExtResource("2")
+format = 2
+

--- a/ui/TitleScreen.gd
+++ b/ui/TitleScreen.gd
@@ -2,10 +2,16 @@ extends Control
 class_name TitleScreen
 
 @onready var start_button: Button = $StartButton
+@onready var editor_button: Button = $EditorButton
 
 func _ready() -> void:
-	# Connect start button to launch new game
+	# Connect buttons to launch game or editor
 	start_button.pressed.connect(_on_start_pressed)
+	editor_button.pressed.connect(_on_editor_pressed)
 
 func _on_start_pressed() -> void:
 	get_tree().change_scene_to_file("res://main.tscn")
+
+func _on_editor_pressed() -> void:
+	# Load the level editor scene
+	get_tree().change_scene_to_file("res://levels/LevelEditor.tscn")

--- a/ui/TitleScreen.tscn
+++ b/ui/TitleScreen.tscn
@@ -9,3 +9,8 @@ script = ExtResource("1")
 position = Vector2(200, 200)
 text = "Start"
 theme_override_font_sizes/font_size = 40
+
+[node name="EditorButton" type="Button" parent="."]
+position = Vector2(200, 260)
+text = "Level Editor"
+theme_override_font_sizes/font_size = 40


### PR DESCRIPTION
## Summary
- add a basic `LevelEditor` scene for painting tiles and saving a level
- hook up a new **Level Editor** button on the title screen

## Testing
- `godot3 --headless --quit` *(fails: `config_version` from newer engine; X11 Display not available)*

------
https://chatgpt.com/codex/tasks/task_e_68c547c11d3c832ebbfa8b5b6deccf43