### PR TITLE
Add game over screen with continue option

### DIFF
--- a/ui/GameOver.gd
+++ b/ui/GameOver.gd
@@ -1,0 +1,20 @@
+extends Control
+class_name GameOver
+
+@onready var continue_button: Button = $CenterContainer/VBoxContainer/ContinueButton
+
+func _ready() -> void:
+	# Allow processing even when the tree is paused
+	process_mode = Node.PROCESS_MODE_ALWAYS
+	visible = false
+	continue_button.pressed.connect(_on_continue_pressed)
+
+func show_game_over() -> void:
+	# Display game over screen and pause the game
+	visible = true
+	get_tree().paused = true
+
+func _on_continue_pressed() -> void:
+	# Resume the game and restart the main scene
+	get_tree().paused = false
+	get_tree().change_scene_to_file("res://main.tscn")

--- a/ui/GameOver.gd.uid
+++ b/ui/GameOver.gd.uid
@@ -1,0 +1,1 @@
+uid://bg0vypn34l3q

--- a/ui/GameOver.tscn
+++ b/ui/GameOver.tscn
@@ -1,0 +1,29 @@
+[gd_scene load_steps=2 format=3 uid="uid://gqnczf3k0n1t"]
+
+[ext_resource type="Script" uid="uid://bg0vypn34l3q" path="res://ui/GameOver.gd" id="1"]
+
+[node name="GameOver" type="Control"]
+script = ExtResource("1")
+visible = false
+
+[node name="ColorRect" type="ColorRect" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+color = Color(0, 0, 0, 0.5)
+
+[node name="CenterContainer" type="CenterContainer" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="CenterContainer"]
+alignment = 1
+
+[node name="Label" type="Label" parent="CenterContainer/VBoxContainer"]
+text = "Game Over"
+theme_override_font_sizes/font_size = 50
+
+[node name="ContinueButton" type="Button" parent="CenterContainer/VBoxContainer"]
+text = "Continue"
+theme_override_font_sizes/font_size = 40

--- a/ui/HUD.gd
+++ b/ui/HUD.gd
@@ -15,6 +15,7 @@ var next_life_score: int = extra_life_score
 @onready var lives_label: Label = $Lives
 @onready var flash_rect: ColorRect = $Flash
 @onready var level_name_label: Label = $LevelName
+@onready var game_over: GameOver = $GameOver # Game over overlay
 
 func _ready() -> void:
 	_update()
@@ -35,6 +36,9 @@ func _process(delta: float) -> void:
 func _on_player_hit(damage: int) -> void:
 	lives -= damage
 	_update()
+	# Show game over when lives are depleted
+	if lives <= 0 and is_instance_valid(game_over):
+		game_over.show_game_over()
 
 func _on_enemy_killed(points: int) -> void:
 	score += points

--- a/ui/HUD.tscn
+++ b/ui/HUD.tscn
@@ -1,6 +1,8 @@
-[gd_scene load_steps=2 format=3 uid="uid://do0mdp7086duo"]
+[gd_scene load_steps=3 format=3 uid="uid://do0mdp7086duo"]
 
 [ext_resource type="Script" uid="uid://dq1fvb1e51y0x" path="res://ui/HUD.gd" id="1"]
+
+[ext_resource type="PackedScene" uid="uid://gqnczf3k0n1t" path="res://ui/GameOver.tscn" id="2"]
 
 [node name="HUD" type="CanvasLayer"]
 script = ExtResource("1")
@@ -34,3 +36,5 @@ anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 color = Color(1, 1, 1, 0)
+
+[node name="GameOver" parent="." instance=ExtResource("2")]


### PR DESCRIPTION
## Summary
- show game over screen when player runs out of lives
- add continue button to restart main scene

## Testing
- `gdlint $(git ls-files '*.gd')` *(fails: existing style issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c55f617a1c832eacee2b580cd6765d